### PR TITLE
Fix service lifetime issues

### DIFF
--- a/source/VMelnalksnis.NordigenDotNet.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/source/VMelnalksnis.NordigenDotNet.DependencyInjection/ServiceCollectionExtensions.cs
@@ -60,10 +60,10 @@ public static class ServiceCollectionExtensions
 			.AddTransient<IAgreementClient, AgreementClient>()
 			.AddTransient<IInstitutionClient, InstitutionClient>()
 			.AddTransient<IRequisitionClient, RequisitionClient>()
-			.AddTransient(provider => provider.GetRequiredService<IOptionsSnapshot<NordigenOptions>>().Value)
+			.AddTransient(provider => provider.GetRequiredService<IOptionsMonitor<NordigenOptions>>().CurrentValue)
 			.AddHttpClient<NordigenHttpClient>((provider, client) =>
 			{
-				client.BaseAddress = provider.GetRequiredService<IOptionsSnapshot<NordigenOptions>>().Value.BaseAddress;
+				client.BaseAddress = provider.GetRequiredService<IOptionsMonitor<NordigenOptions>>().CurrentValue.BaseAddress;
 
 				var assembly = typeof(INordigenClient).Assembly.GetName();
 


### PR DESCRIPTION
Got
```
Cannot resolve scoped service 'Microsoft.Extensions.Options.IOptionsSnapshot`1[VMelnalksnis.NordigenDotNet.NordigenOptions]' from root provider.
```
exception in ASP.NET Core, I'm guessing this should fix it.