### PR TITLE
Fix integrations tests, reduce dependency injection overhead

### DIFF
--- a/source/VMelnalksnis.NordigenDotNet.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/source/VMelnalksnis.NordigenDotNet.DependencyInjection/ServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ public static class ServiceCollectionExtensions
 
 		return serviceCollection
 			.AddSingleton<NordigenTokenCache>()
+			.AddSingleton<NordigenJsonSerializerOptions>()
 			.AddTransient<INordigenClient, NordigenClient>()
 			.AddTransient<IAccountClient, AccountClient>()
 			.AddTransient<IAgreementClient, AgreementClient>()

--- a/source/VMelnalksnis.NordigenDotNet/Accounts/AccountClient.cs
+++ b/source/VMelnalksnis.NordigenDotNet/Accounts/AccountClient.cs
@@ -27,7 +27,7 @@ public sealed class AccountClient : IAccountClient
 	public async Task<Account> Get(Guid id, CancellationToken cancellationToken = default)
 	{
 		var account = await _nordigenHttpClient
-			.GetAsJson<Account>(Routes.Accounts.IdUri(id), cancellationToken)
+			.Get<Account>(Routes.Accounts.IdUri(id), cancellationToken)
 			.ConfigureAwait(false);
 
 		return account!;
@@ -37,7 +37,7 @@ public sealed class AccountClient : IAccountClient
 	public async Task<List<Balance>> GetBalances(Guid id, CancellationToken cancellationToken = default)
 	{
 		var balances = await _nordigenHttpClient
-			.GetAsJson<BalancesWrapper>(Routes.Accounts.BalancesUri(id), cancellationToken)
+			.Get<BalancesWrapper>(Routes.Accounts.BalancesUri(id), cancellationToken)
 			.ConfigureAwait(false);
 
 		return balances!.Balances;
@@ -47,7 +47,7 @@ public sealed class AccountClient : IAccountClient
 	public async Task<AccountDetails> GetDetails(Guid id, CancellationToken cancellationToken = default)
 	{
 		var details = await _nordigenHttpClient
-			.GetAsJson<AccountDetailsWrapper>(Routes.Accounts.DetailsUri(id), cancellationToken)
+			.Get<AccountDetailsWrapper>(Routes.Accounts.DetailsUri(id), cancellationToken)
 			.ConfigureAwait(false);
 
 		return details!.Account;
@@ -62,7 +62,7 @@ public sealed class AccountClient : IAccountClient
 		var uri = Routes.Accounts.TransactionsUri(id, interval);
 
 		var transactions = await _nordigenHttpClient
-			.GetAsJson<TransactionsWrapper>(uri, cancellationToken)
+			.Get<TransactionsWrapper>(uri, cancellationToken)
 			.ConfigureAwait(false);
 
 		return transactions!.Transactions;

--- a/source/VMelnalksnis.NordigenDotNet/Agreements/AgreementClient.cs
+++ b/source/VMelnalksnis.NordigenDotNet/Agreements/AgreementClient.cs
@@ -24,15 +24,14 @@ public sealed class AgreementClient : IAgreementClient
 	/// <inheritdoc />
 	public IAsyncEnumerable<EndUserAgreement> Get(int pageSize = 100, CancellationToken cancellationToken = default)
 	{
-		var requestUri = $"{Routes.Agreements.Uri}?limit={pageSize}&offset=0";
-		return _nordigenHttpClient.GetAsJsonPaginated<EndUserAgreement>(requestUri, cancellationToken);
+		return _nordigenHttpClient.GetPaginated<EndUserAgreement>(Routes.Agreements.PaginatedUri(100), cancellationToken);
 	}
 
 	/// <inheritdoc />
 	public async Task<EndUserAgreement> Get(Guid id, CancellationToken cancellationToken = default)
 	{
 		var agreement = await _nordigenHttpClient
-			.GetAsJson<EndUserAgreement>(Routes.Agreements.IdUri(id), cancellationToken)
+			.Get<EndUserAgreement>(Routes.Agreements.IdUri(id), cancellationToken)
 			.ConfigureAwait(false);
 
 		return agreement!;
@@ -42,7 +41,7 @@ public sealed class AgreementClient : IAgreementClient
 	public async Task<EndUserAgreement> Post(EndUserAgreementCreation agreementCreation)
 	{
 		var agreement = await _nordigenHttpClient
-			.PostAsJson<EndUserAgreementCreation, EndUserAgreement>(Routes.Agreements.Uri, agreementCreation)
+			.Post<EndUserAgreementCreation, EndUserAgreement>(Routes.Agreements.Uri, agreementCreation)
 			.ConfigureAwait(false);
 
 		return agreement!;
@@ -58,7 +57,7 @@ public sealed class AgreementClient : IAgreementClient
 	public async Task<EndUserAgreement> Put(Guid id, EndUserAgreementAcceptance acceptance)
 	{
 		var agreement = await _nordigenHttpClient
-			.PutAsJson<EndUserAgreementAcceptance, EndUserAgreement>(Routes.Agreements.AcceptUri(id), acceptance)
+			.Put<EndUserAgreementAcceptance, EndUserAgreement>(Routes.Agreements.AcceptUri(id), acceptance)
 			.ConfigureAwait(false);
 
 		return agreement!;

--- a/source/VMelnalksnis.NordigenDotNet/Institutions/InstitutionClient.cs
+++ b/source/VMelnalksnis.NordigenDotNet/Institutions/InstitutionClient.cs
@@ -24,7 +24,7 @@ public sealed class InstitutionClient : IInstitutionClient
 	public async Task<List<Institution>> GetByCountry(string countryCode, CancellationToken cancellationToken = default)
 	{
 		var institutions = await _nordigenHttpClient
-			.GetAsJson<List<Institution>>(Routes.Institutions.CountryUri(countryCode), cancellationToken)
+			.Get<List<Institution>>(Routes.Institutions.CountryUri(countryCode), cancellationToken)
 			.ConfigureAwait(false);
 
 		return institutions!;
@@ -34,7 +34,7 @@ public sealed class InstitutionClient : IInstitutionClient
 	public async Task<Institution> Get(string id, CancellationToken cancellationToken = default)
 	{
 		var institution = await _nordigenHttpClient
-			.GetAsJson<Institution>(Routes.Institutions.IdUri(id), cancellationToken)
+			.Get<Institution>(Routes.Institutions.IdUri(id), cancellationToken)
 			.ConfigureAwait(false);
 
 		return institution!;

--- a/source/VMelnalksnis.NordigenDotNet/NordigenHttpClient.cs
+++ b/source/VMelnalksnis.NordigenDotNet/NordigenHttpClient.cs
@@ -7,12 +7,8 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-
-using NodaTime;
-using NodaTime.Serialization.SystemTextJson;
 
 namespace VMelnalksnis.NordigenDotNet;
 
@@ -24,15 +20,11 @@ public sealed class NordigenHttpClient
 
 	/// <summary>Initializes a new instance of the <see cref="NordigenHttpClient"/> class.</summary>
 	/// <param name="httpClient">Http client configured for making requests to the Nordigen API.</param>
-	/// <param name="dateTimeZoneProvider">Time zone provider for date and time serialization.</param>
-	public NordigenHttpClient(HttpClient httpClient, IDateTimeZoneProvider dateTimeZoneProvider)
+	/// <param name="nordigenJsonSerializerOptions">Nordigen specific instance of <see cref="JsonSerializerOptions"/>.</param>
+	public NordigenHttpClient(HttpClient httpClient, NordigenJsonSerializerOptions nordigenJsonSerializerOptions)
 	{
 		_httpClient = httpClient;
-
-		_serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
-		{
-			Converters = { new JsonStringEnumConverter() },
-		}.ConfigureForNodaTime(dateTimeZoneProvider);
+		_serializerOptions = nordigenJsonSerializerOptions.Options;
 	}
 
 	internal async Task<TResult?> Get<TResult>(string requestUri, CancellationToken cancellationToken)

--- a/source/VMelnalksnis.NordigenDotNet/NordigenJsonSerializerOptions.cs
+++ b/source/VMelnalksnis.NordigenDotNet/NordigenJsonSerializerOptions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2022 Valters Melnalksnis
+// Licensed under the Apache License 2.0.
+// See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
+
+namespace VMelnalksnis.NordigenDotNet;
+
+/// <summary><see cref="JsonSerializerOptions"/> for <see cref="NordigenHttpClient"/>.</summary>
+public sealed class NordigenJsonSerializerOptions
+{
+	/// <summary>Initializes a new instance of the <see cref="NordigenJsonSerializerOptions"/> class.</summary>
+	/// <param name="dateTimeZoneProvider">Time zone provider for date and time serialization.</param>
+	public NordigenJsonSerializerOptions(IDateTimeZoneProvider dateTimeZoneProvider)
+	{
+		Options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+		{
+			Converters = { new JsonStringEnumConverter() },
+		}.ConfigureForNodaTime(dateTimeZoneProvider);
+	}
+
+	internal JsonSerializerOptions Options { get; }
+}

--- a/source/VMelnalksnis.NordigenDotNet/Requisitions/RequisitionClient.cs
+++ b/source/VMelnalksnis.NordigenDotNet/Requisitions/RequisitionClient.cs
@@ -24,15 +24,14 @@ public sealed class RequisitionClient : IRequisitionClient
 	/// <inheritdoc />
 	public IAsyncEnumerable<Requisition> Get(int pageSize = 100, CancellationToken cancellationToken = default)
 	{
-		var requestUri = $"{Routes.Requisitions.Uri}?limit={pageSize}&offset=0";
-		return _nordigenHttpClient.GetAsJsonPaginated<Requisition>(requestUri, cancellationToken);
+		return _nordigenHttpClient.GetPaginated<Requisition>(Routes.Requisitions.PaginatedUri(pageSize), cancellationToken);
 	}
 
 	/// <inheritdoc />
 	public async Task<Requisition> Get(Guid id, CancellationToken cancellationToken = default)
 	{
 		var requisition = await _nordigenHttpClient
-			.GetAsJson<Requisition>(Routes.Requisitions.IdUri(id), cancellationToken)
+			.Get<Requisition>(Routes.Requisitions.IdUri(id), cancellationToken)
 			.ConfigureAwait(false);
 
 		return requisition!;
@@ -42,7 +41,7 @@ public sealed class RequisitionClient : IRequisitionClient
 	public async Task<Requisition> Post(RequisitionCreation requisitionCreation)
 	{
 		var requisition = await _nordigenHttpClient
-			.PostAsJson<RequisitionCreation, Requisition>(Routes.Requisitions.Uri, requisitionCreation)
+			.Post<RequisitionCreation, Requisition>(Routes.Requisitions.Uri, requisitionCreation)
 			.ConfigureAwait(false);
 
 		return requisition!;

--- a/source/VMelnalksnis.NordigenDotNet/Routes.cs
+++ b/source/VMelnalksnis.NordigenDotNet/Routes.cs
@@ -10,9 +10,13 @@ namespace VMelnalksnis.NordigenDotNet;
 
 internal static class Routes
 {
+	private static string PaginatedUri(string baseUri, int pageSize) => $"{baseUri}?limit={pageSize}&offset=0";
+
 	internal static class Agreements
 	{
 		internal const string Uri = "api/v2/agreements/enduser/";
+
+		internal static string PaginatedUri(int pageSize) => Routes.PaginatedUri(Uri, pageSize);
 
 		internal static string IdUri(Guid id) => $"{Uri}{id:N}/";
 
@@ -48,6 +52,8 @@ internal static class Routes
 	internal static class Requisitions
 	{
 		internal const string Uri = "api/v2/requisitions/";
+
+		internal static string PaginatedUri(int pageSize) => Routes.PaginatedUri(Uri, pageSize);
 
 		internal static string IdUri(Guid id) => $"{Uri}{id:N}/";
 	}

--- a/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Accounts/AccountClientTests.cs
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Accounts/AccountClientTests.cs
@@ -24,7 +24,7 @@ public sealed class AccountClientTests : IClassFixture<ServiceProviderFixture>
 	public AccountClientTests(ITestOutputHelper testOutputHelper, ServiceProviderFixture serviceProviderFixture)
 	{
 		_testOutputHelper = testOutputHelper;
-		_nordigenClient = serviceProviderFixture.NordigenClient;
+		_nordigenClient = serviceProviderFixture.GetNordigenClient(testOutputHelper);
 
 		_requisition = GetRequisition().GetAwaiter().GetResult();
 	}

--- a/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Agreements/AgreementClientTests.cs
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Agreements/AgreementClientTests.cs
@@ -11,6 +11,8 @@ using NodaTime;
 
 using VMelnalksnis.NordigenDotNet.Agreements;
 
+using Xunit.Abstractions;
+
 using static VMelnalksnis.NordigenDotNet.Tests.Integration.ServiceProviderFixture;
 
 namespace VMelnalksnis.NordigenDotNet.Tests.Integration.Agreements;
@@ -19,9 +21,9 @@ public sealed class AgreementClientTests : IClassFixture<ServiceProviderFixture>
 {
 	private readonly INordigenClient _nordigenClient;
 
-	public AgreementClientTests(ServiceProviderFixture serviceProviderFixture)
+	public AgreementClientTests(ITestOutputHelper testOutputHelper, ServiceProviderFixture serviceProviderFixture)
 	{
-		_nordigenClient = serviceProviderFixture.NordigenClient;
+		_nordigenClient = serviceProviderFixture.GetNordigenClient(testOutputHelper);
 	}
 
 	[Fact]

--- a/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Institutions/InstitutionClientTests.cs
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Institutions/InstitutionClientTests.cs
@@ -5,15 +5,17 @@
 using System;
 using System.Threading.Tasks;
 
+using Xunit.Abstractions;
+
 namespace VMelnalksnis.NordigenDotNet.Tests.Integration.Institutions;
 
 public sealed class InstitutionClientTests : IClassFixture<ServiceProviderFixture>
 {
 	private readonly INordigenClient _nordigenClient;
 
-	public InstitutionClientTests(ServiceProviderFixture serviceProviderFixture)
+	public InstitutionClientTests(ITestOutputHelper testOutputHelper, ServiceProviderFixture serviceProviderFixture)
 	{
-		_nordigenClient = serviceProviderFixture.NordigenClient;
+		_nordigenClient = serviceProviderFixture.GetNordigenClient(testOutputHelper);
 	}
 
 	[Fact]

--- a/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Tokens/TokenDelegatingHandlerTests.cs
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Tokens/TokenDelegatingHandlerTests.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 
 using NodaTime.Testing;
 
+using Xunit.Abstractions;
+
 namespace VMelnalksnis.NordigenDotNet.Tests.Integration.Tokens;
 
 public sealed class TokenDelegatingHandlerTests : IClassFixture<ServiceProviderFixture>
@@ -14,10 +16,10 @@ public sealed class TokenDelegatingHandlerTests : IClassFixture<ServiceProviderF
 	private readonly FakeClock _fakeClock;
 	private readonly INordigenClient _nordigenClient;
 
-	public TokenDelegatingHandlerTests(ServiceProviderFixture serviceProviderFixture)
+	public TokenDelegatingHandlerTests(ITestOutputHelper testOutputHelper, ServiceProviderFixture serviceProviderFixture)
 	{
 		_fakeClock = serviceProviderFixture.Clock;
-		_nordigenClient = serviceProviderFixture.NordigenClient;
+		_nordigenClient = serviceProviderFixture.GetNordigenClient(testOutputHelper);
 	}
 
 	[Theory]

--- a/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/VMelnalksnis.NordigenDotNet.Tests.Integration.csproj
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/VMelnalksnis.NordigenDotNet.Tests.Integration.csproj
@@ -16,6 +16,9 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1"/>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0"/>
 		<PackageReference Include="NodaTime.Testing" Version="3.1.0"/>
+		<PackageReference Include="Serilog" Version="2.11.0"/>
+		<PackageReference Include="Serilog.AspNetCore" Version="5.0.0"/>
+		<PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.3"/>
 		<PackageReference Include="System.Linq.Async" Version="6.0.1"/>
 	</ItemGroup>
 


### PR DESCRIPTION
1. Fixes asserts in integration tests on data that is changing
2. Reduces the execution time and memory allocation of `GetRequiredService<INordigenClient>()` by an order of magnitude by caching the user agent header value and `JsonSerializerOptions` instance