### PR TITLE
Add new properties to Transactions

### DIFF
--- a/source/VMelnalksnis.NordigenDotNet/Accounts/BookedTransaction.cs
+++ b/source/VMelnalksnis.NordigenDotNet/Accounts/BookedTransaction.cs
@@ -14,17 +14,11 @@ public record BookedTransaction : Transaction
 	/// <summary>Gets or sets a unique transaction id created by the <see cref="Institution"/>.</summary>
 	public string TransactionId { get; set; } = null!;
 
-	/// <summary>Gets or sets the date when an entry is posted to an account on the account servicer's books.</summary>
-	public LocalDate BookingDate { get; set; }
-
 	/// <summary>Gets or sets the name of the counterparty that sends <see cref="Transaction.TransactionAmount"/> during the transaction.</summary>
 	public string? DebtorName { get; set; }
 
 	/// <summary>Gets or sets the account of the counterparty that sends <see cref="Transaction.TransactionAmount"/> during the transaction.</summary>
 	public TransactionAccount? DebtorAccount { get; set; }
-
-	/// <summary>Gets or sets the name of the counterparty that receives <see cref="Transaction.TransactionAmount"/> during the transaction.</summary>
-	public string? CreditorName { get; set; }
 
 	/// <summary>Gets or sets the account of the counterparty that receives <see cref="Transaction.TransactionAmount"/> during the transaction.</summary>
 	public TransactionAccount? CreditorAccount { get; set; }
@@ -36,9 +30,6 @@ public record BookedTransaction : Transaction
 	/// PMNT-IRCT-STDO
 	/// </code></example>
 	public string? BankTransactionCode { get; set; }
-
-	/// <summary>Gets or sets a transaction id, used both by the transaction and any fees paid to the <see cref="Institution"/> for the transaction.</summary>
-	public string? EntryReference { get; set; }
 
 	/// <summary>Gets or sets additional structured information about the transaction from the institution.</summary>
 	/// <example>

--- a/source/VMelnalksnis.NordigenDotNet/Accounts/CurrencyExchange.cs
+++ b/source/VMelnalksnis.NordigenDotNet/Accounts/CurrencyExchange.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json.Serialization;
+
+namespace VMelnalksnis.NordigenDotNet.Accounts;
+
+/// <summary>An exchange rate between currencies.</summary>
+public record CurrencyExchange
+{
+	/// <summary>Gets or sets a ISO 4217 currency code.</summary>
+	public string SourceCurrency { get; set; } = null!;
+
+	/// <summary>Gets or sets the exchange rate.</summary>
+	[JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+	public decimal ExchangeRate { get; set; }
+}

--- a/source/VMelnalksnis.NordigenDotNet/Accounts/Transaction.cs
+++ b/source/VMelnalksnis.NordigenDotNet/Accounts/Transaction.cs
@@ -11,8 +11,14 @@ namespace VMelnalksnis.NordigenDotNet.Accounts;
 /// <summary>Common information for all transactions.</summary>
 public abstract record Transaction
 {
+	/// <summary>Gets or sets the name of the counterparty that receives <see cref="Transaction.TransactionAmount"/> during the transaction.</summary>
+	public string? CreditorName { get; set; }
+
 	/// <summary>Gets or sets the amount transferred in this transaction.</summary>
 	public AmountInCurrency TransactionAmount { get; set; } = null!;
+
+	/// <summary>Gets or sets the exchange rate used for this transaction.</summary>
+	public CurrencyExchange CurrencyExchange { get; set; } = null!;
 
 	/// <summary>Gets or sets unstructured information about the transaction, usually added by the debtor.</summary>
 	[JsonPropertyName("remittanceInformationUnstructured")]
@@ -22,6 +28,25 @@ public abstract record Transaction
 	[JsonPropertyName("remittanceInformationStructured")]
 	public string? StructuredInformation { get; set; }
 
+	/// <summary>Gets or sets a transaction id, used both by the transaction and any fees paid to the <see cref="Institution"/> for the transaction.</summary>
+	public string? EntryReference { get; set; }
+
 	/// <summary>Gets or sets the date when the transaction was valued at.</summary>
 	public LocalDate? ValueDate { get; set; }
+
+	/// <summary>Gets or sets the date and time when the transaction was valued at.</summary>
+	public LocalDateTime? ValueDateTime { get; set; }
+
+	/// <summary>Gets or sets the date and time when an entry is posted to an account on the account servicer's books.</summary>
+	public LocalDate? BookingDate { get; set; }
+
+	/// <summary>Gets or sets the date when an entry is posted to an account on the account servicer's books.</summary>
+	public LocalDateTime? BookingDateTime { get; set; }
+
+	/// <summary>Gets or sets additional information which be used by the financial institution to
+	/// transport additional transaction related information.</summary>
+	public string? AdditionalInformation { get; set; }
+
+	/// <summary>Gets or sets merchant category code as defined by card issuer.</summary>
+	public string? MerchantCategoryCode { get; set; }
 }

--- a/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Accounts/AccountClientTests.cs
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Accounts/AccountClientTests.cs
@@ -60,16 +60,19 @@ public sealed class AccountClientTests : IClassFixture<ServiceProviderFixture>, 
 	{
 		var accountDetails = await _nordigenClient.Accounts.GetDetails(_accountId);
 
-		accountDetails.Should().BeEquivalentTo(new AccountDetails
+		accountDetails.Should().BeEquivalentTo(
+			new AccountDetails
 		{
 			ResourceId = "01F3NS4YV94RA29YCH8R0F6BMF",
-			Iban = "GL2225000000025007",
 			Currency = "EUR",
 			OwnerName = "John Doe",
 			Name = "Main Account",
 			Product = "Checkings",
 			CashAccountType = "CACC",
-		});
+		},
+			option => option .Excluding(x => x.Iban));
+
+		accountDetails.Iban.Should().Contain("GL");
 	}
 
 	[Fact]

--- a/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Accounts/AccountClientTests.cs
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Accounts/AccountClientTests.cs
@@ -70,7 +70,7 @@ public sealed class AccountClientTests : IClassFixture<ServiceProviderFixture>, 
 			Product = "Checkings",
 			CashAccountType = "CACC",
 		},
-			option => option .Excluding(x => x.Iban));
+			option => option.Excluding(x => x.Iban));
 
 		accountDetails.Iban.Should().Contain("GL");
 	}


### PR DESCRIPTION
### Changes

Resolves: https://github.com/VMelnalksnis/NordigenDotNet/issues/167

### Testing

I updated the `getDetails` test to only check for the `GL` prefix on IBAN, as I observed this seems to change between users and test runs for the sandbox.

These new fields don't seem to be present on the sandbox data, I wonder if there's any value in mocking the API responses from Nordigen in some tests to validate the behaviour of the library for data not available in sandbox.