### PR TITLE
Update DateTime datatypes to support non-Zulu time values

### DIFF
--- a/source/VMelnalksnis.NordigenDotNet/Accounts/Transaction.cs
+++ b/source/VMelnalksnis.NordigenDotNet/Accounts/Transaction.cs
@@ -33,13 +33,13 @@ public abstract record Transaction
 	public LocalDate? ValueDate { get; set; }
 
 	/// <summary>Gets or sets the date and time when the transaction was valued at.</summary>
-	public Instant? ValueDateTime { get; set; }
+	public OffsetDateTime? ValueDateTime { get; set; }
 
 	/// <summary>Gets or sets the date and time when an entry is posted to an account on the account servicer's books.</summary>
 	public LocalDate? BookingDate { get; set; }
 
 	/// <summary>Gets or sets the date when an entry is posted to an account on the account servicer's books.</summary>
-	public Instant? BookingDateTime { get; set; }
+	public OffsetDateTime? BookingDateTime { get; set; }
 
 	/// <summary>
 	/// Gets or sets additional information which be used by the financial institution

--- a/tests/VMelnalksnis.NordigenDotNet.Tests/Accounts/AccountClientTests.cs
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests/Accounts/AccountClientTests.cs
@@ -51,7 +51,7 @@ public sealed class AccountClientTests
 			CreditorName = "Alderaan Coffee",
 			CurrencyExchange = new()
 			{
-				ExchangeRate = decimal.Parse("0.00"),
+				ExchangeRate = 0.00m,
 				SourceCurrency = "GBP",
 			},
 			EntryReference = "2023111101697308",
@@ -75,7 +75,7 @@ public sealed class AccountClientTests
 			CreditorName = "Alderaan Coffee",
 			CurrencyExchange = new()
 			{
-				ExchangeRate = decimal.Parse("0.00"),
+				ExchangeRate = 0.00m,
 				SourceCurrency = "GBP",
 			},
 			EntryReference = "2023111101697308",
@@ -101,7 +101,7 @@ public sealed class AccountClientTests
 			CreditorName = "Alderaan Coffee",
 			CurrencyExchange = new()
 			{
-				ExchangeRate = decimal.Parse("0.00"),
+				ExchangeRate = 0.00m,
 				SourceCurrency = "GBP",
 			},
 			EntryReference = "2023111101697308",
@@ -127,7 +127,7 @@ public sealed class AccountClientTests
 			CreditorName = "Alderaan Coffee",
 			CurrencyExchange = new()
 			{
-				ExchangeRate = decimal.Parse("0.00"),
+				ExchangeRate = 0.00m,
 				SourceCurrency = "GBP",
 			},
 			EntryReference = "2023111101697308",

--- a/tests/VMelnalksnis.NordigenDotNet.Tests/Accounts/AccountClientTests.cs
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests/Accounts/AccountClientTests.cs
@@ -60,7 +60,7 @@ public sealed class AccountClientTests
 			TransactionAmount = new()
 			{
 				Currency = "GBP",
-				Amount = decimal.Parse("-10.00"),
+				Amount = -10.00m,
 			},
 			TransactionId = "2023111101697308-1",
 			UnstructuredInformation = "Alderaan Coffee - Alderaan",
@@ -84,7 +84,7 @@ public sealed class AccountClientTests
 			TransactionAmount = new()
 			{
 				Currency = "GBP",
-				Amount = decimal.Parse("-10.00"),
+				Amount = -10.00m,
 			},
 			UnstructuredInformation = "Alderaan Coffee - Alderaan",
 			TransactionId = "2023111101697308-1",
@@ -110,7 +110,7 @@ public sealed class AccountClientTests
 			TransactionAmount = new()
 			{
 				Currency = "GBP",
-				Amount = decimal.Parse("-10.00"),
+				Amount = -10.00m,
 			},
 			UnstructuredInformation = "Alderaan Coffee - Alderaan",
 			BookingDate = bookingDate.InZone(DateTimeZone.Utc).Date,
@@ -136,7 +136,7 @@ public sealed class AccountClientTests
 			TransactionAmount = new()
 			{
 				Currency = "GBP",
-				Amount = decimal.Parse("-10.00"),
+				Amount = -10.00m,
 			},
 			UnstructuredInformation = "Alderaan Coffee - Alderaan",
 			TransactionId = "2023111101697308-3",

--- a/tests/VMelnalksnis.NordigenDotNet.Tests/Accounts/AccountClientTests.cs
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests/Accounts/AccountClientTests.cs
@@ -43,61 +43,120 @@ public sealed class AccountClientTests
 		var data = TestData.GetTransactions.Result;
 		var bookingDate = Instant.FromUtc(2023, 11, 8, 10, 05);
 		var valueDate = Instant.FromUtc(2023, 11, 10, 12, 12, 12);
+
+		var bankTransactionPending = new PendingTransaction()
+		{
+			AdditionalInformation = "Coffee",
+			BankTransactionCode = "PMNT",
+			CreditorName = "Alderaan Coffee",
+			CurrencyExchange = new()
+			{
+				ExchangeRate = decimal.Parse("0.00"),
+				SourceCurrency = "GBP",
+			},
+			EntryReference = "2023111101697308",
+			MerchantCategoryCode = "123",
+			StructuredInformation = "Structured Alderaan - Coffee - Alderaan",
+			TransactionAmount = new()
+			{
+				Currency = "GBP",
+				Amount = decimal.Parse("-10.00"),
+			},
+			TransactionId = "2023111101697308-1",
+			UnstructuredInformation = "Alderaan Coffee - Alderaan",
+			BookingDate = bookingDate.InZone(DateTimeZone.Utc).Date,
+			BookingDateTime = bookingDate.WithOffset(Offset.Zero),
+		};
+
+		var bankTransactionWithZuluTime = new BookedTransaction()
+		{
+			AdditionalInformation = "Coffee",
+			BankTransactionCode = "PMNT",
+			CreditorName = "Alderaan Coffee",
+			CurrencyExchange = new()
+			{
+				ExchangeRate = decimal.Parse("0.00"),
+				SourceCurrency = "GBP",
+			},
+			EntryReference = "2023111101697308",
+			MerchantCategoryCode = "123",
+			StructuredInformation = "Structured Alderaan - Coffee - Alderaan",
+			TransactionAmount = new()
+			{
+				Currency = "GBP",
+				Amount = decimal.Parse("-10.00"),
+			},
+			UnstructuredInformation = "Alderaan Coffee - Alderaan",
+			TransactionId = "2023111101697308-1",
+			BookingDate = bookingDate.InZone(DateTimeZone.Utc).Date,
+			BookingDateTime = bookingDate.WithOffset(Offset.Zero),
+			ValueDate = valueDate.InZone(DateTimeZone.Utc).Date,
+			ValueDateTime = valueDate.WithOffset(Offset.Zero),
+		};
+
+		var bankTransactionWithZeroOffset = new BookedTransaction()
+		{
+			AdditionalInformation = "Coffee",
+			BankTransactionCode = "PMNT",
+			CreditorName = "Alderaan Coffee",
+			CurrencyExchange = new()
+			{
+				ExchangeRate = decimal.Parse("0.00"),
+				SourceCurrency = "GBP",
+			},
+			EntryReference = "2023111101697308",
+			MerchantCategoryCode = "123",
+			StructuredInformation = "Structured Alderaan - Coffee - Alderaan",
+			TransactionAmount = new()
+			{
+				Currency = "GBP",
+				Amount = decimal.Parse("-10.00"),
+			},
+			UnstructuredInformation = "Alderaan Coffee - Alderaan",
+			BookingDate = bookingDate.InZone(DateTimeZone.Utc).Date,
+			BookingDateTime = bookingDate.WithOffset(Offset.Zero),
+			ValueDate = valueDate.InZone(DateTimeZone.Utc).Date,
+			ValueDateTime = valueDate.WithOffset(Offset.Zero),
+			TransactionId = "2023111101697308-2",
+		};
+
+		var bankTransactionWith1HourOffset = new BookedTransaction()
+		{
+			AdditionalInformation = "Coffee",
+			BankTransactionCode = "PMNT",
+			CreditorName = "Alderaan Coffee",
+			CurrencyExchange = new()
+			{
+				ExchangeRate = decimal.Parse("0.00"),
+				SourceCurrency = "GBP",
+			},
+			EntryReference = "2023111101697308",
+			MerchantCategoryCode = "123",
+			StructuredInformation = "Structured Alderaan - Coffee - Alderaan",
+			TransactionAmount = new()
+			{
+				Currency = "GBP",
+				Amount = decimal.Parse("-10.00"),
+			},
+			UnstructuredInformation = "Alderaan Coffee - Alderaan",
+			TransactionId = "2023111101697308-3",
+			BookingDate = bookingDate.InZone(DateTimeZone.Utc).Date,
+			BookingDateTime = bookingDate.WithOffset(Offset.FromHours(1)).PlusHours(-1),
+			ValueDate = valueDate.InZone(DateTimeZone.Utc).Date,
+			ValueDateTime = valueDate.WithOffset(Offset.FromHours(1)).PlusHours(-1),
+		};
+
 		var expected = new Transactions
 		{
 			Booked = new()
 			{
-				new()
-				{
-					AdditionalInformation = "Coffee",
-					BankTransactionCode = "PMNT",
-					BookingDate = bookingDate.InZone(DateTimeZone.Utc).Date,
-					BookingDateTime = bookingDate,
-					CreditorName = "Alderaan Coffee",
-					CurrencyExchange = new()
-					{
-						ExchangeRate = decimal.Parse("0.00"),
-						SourceCurrency = "GBP",
-					},
-					EntryReference = "2023111101697308-1",
-					MerchantCategoryCode = "123",
-					StructuredInformation = "Structured Alderaan - Coffee - Alderaan",
-					TransactionAmount = new()
-					{
-						Currency = "GBP",
-						Amount = decimal.Parse("-10.00"),
-					},
-					TransactionId = "2023111101697308-1",
-					UnstructuredInformation = "Alderaan Coffee - Alderaan",
-					ValueDate = valueDate.InZone(DateTimeZone.Utc).Date,
-					ValueDateTime = valueDate,
-				},
+				bankTransactionWithZuluTime,
+				bankTransactionWithZeroOffset,
+				bankTransactionWith1HourOffset,
 			},
 			Pending = new()
 			{
-				new()
-				{
-					AdditionalInformation = "Coffee",
-					BankTransactionCode = "PMNT",
-					BookingDate = bookingDate.InZone(DateTimeZone.Utc).Date,
-					BookingDateTime = bookingDate,
-					CreditorName = "Alderaan Coffee",
-					CurrencyExchange = new()
-					{
-						ExchangeRate = decimal.Parse("0.00"),
-						SourceCurrency = "GBP",
-					},
-					EntryReference = "2023111101697308-1",
-					MerchantCategoryCode = "123",
-					StructuredInformation = "Structured Alderaan - Coffee - Alderaan",
-					TransactionAmount = new()
-					{
-						Currency = "GBP",
-						Amount = decimal.Parse("-10.00"),
-					},
-					TransactionId = "2023111101697308-1",
-					UnstructuredInformation = "Alderaan Coffee - Alderaan",
-				},
+				bankTransactionPending,
 			},
 		};
 

--- a/tests/VMelnalksnis.NordigenDotNet.Tests/Stubs/Accounts/GetTransactions.json
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests/Stubs/Accounts/GetTransactions.json
@@ -3,11 +3,55 @@
 		"booked": [
 			{
 				"transactionId": "2023111101697308-1",
-				"entryReference": "2023111101697308-1",
+				"entryReference": "2023111101697308",
 				"bookingDate": "2023-11-08",
 				"bookingDateTime": "2023-11-08T10:05:00Z",
 				"valueDate": "2023-11-10",
 				"valueDateTime": "2023-11-10T12:12:12Z",
+				"transactionAmount": {
+					"amount": "-10.00",
+					"currency": "GBP"
+				},
+				"currencyExchange": {
+					"sourceCurrency": "GBP",
+					"exchangeRate": "0.0"
+				},
+				"creditorName": "Alderaan Coffee",
+				"remittanceInformationUnstructured": "Alderaan Coffee - Alderaan",
+				"remittanceInformationStructured": "Structured Alderaan - Coffee - Alderaan",
+				"additionalInformation": "Coffee",
+				"bankTransactionCode": "PMNT",
+				"merchantCategoryCode": "123"
+			},
+			{
+				"transactionId": "2023111101697308-2",
+				"entryReference": "2023111101697308",
+				"bookingDate": "2023-11-08",
+				"bookingDateTime": "2023-11-08T10:05:00+00:00",
+				"valueDate": "2023-11-10",
+				"valueDateTime": "2023-11-10T12:12:12+00:00",
+				"transactionAmount": {
+					"amount": "-10.00",
+					"currency": "GBP"
+				},
+				"currencyExchange": {
+					"sourceCurrency": "GBP",
+					"exchangeRate": "0.0"
+				},
+				"creditorName": "Alderaan Coffee",
+				"remittanceInformationUnstructured": "Alderaan Coffee - Alderaan",
+				"remittanceInformationStructured": "Structured Alderaan - Coffee - Alderaan",
+				"additionalInformation": "Coffee",
+				"bankTransactionCode": "PMNT",
+				"merchantCategoryCode": "123"
+			},
+			{
+				"transactionId": "2023111101697308-3",
+				"entryReference": "2023111101697308",
+				"bookingDate": "2023-11-08",
+				"bookingDateTime": "2023-11-08T10:05:00+01:00",
+				"valueDate": "2023-11-10",
+				"valueDateTime": "2023-11-10T12:12:12+01:00",
 				"transactionAmount": {
 					"amount": "-10.00",
 					"currency": "GBP"
@@ -27,7 +71,7 @@
 		"pending": [
 			{
 				"transactionId": "2023111101697308-1",
-				"entryReference": "2023111101697308-1",
+				"entryReference": "2023111101697308",
 				"bookingDate": "2023-11-08",
 				"bookingDateTime": "2023-11-08T10:05:00Z",
 				"transactionAmount": {


### PR DESCRIPTION
Resolves #202 by using the `OffsetDateTime` type instead of `Instant` 

Adds new unit tests to cover these additonal scenarios 