### PR TITLE
Update the default base address

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           Nordigen__SecretId: ${{ secrets.NORDIGEN_SECRET_ID }}
           Nordigen__SecretKey: ${{ secrets.NORDIGEN_SECRET_KEY }}
+          Logging__LogLevel__Default: "Warning"
 
       - name: Gather Code Coverage
         if: github.event.schedule == null

--- a/source/VMelnalksnis.NordigenDotNet/NordigenOptions.cs
+++ b/source/VMelnalksnis.NordigenDotNet/NordigenOptions.cs
@@ -11,7 +11,7 @@ public sealed record NordigenOptions
 
 	/// <summary>Gets the base address of the Nordigen API.</summary>
 	[Required]
-	public Uri BaseAddress { get; init; } = new("https://ob.nordigen.com/");
+	public Uri BaseAddress { get; init; } = new("https://bankaccountdata.gocardless.com/");
 
 	/// <summary>Gets the secret ID used to create new access tokens.</summary>
 	[Required]

--- a/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Requisitions/RequisitionsClientTests.cs
+++ b/tests/VMelnalksnis.NordigenDotNet.Tests.Integration/Requisitions/RequisitionsClientTests.cs
@@ -68,7 +68,7 @@ public sealed class RequisitionsClientTests : IClassFixture<ServiceProviderFixtu
 			requisition.InstitutionId.Should().BeEquivalentTo(creation.InstitutionId);
 			requisition.Reference.Should().NotBeNullOrWhiteSpace("Nordigen sets it to a random GUID if not specified");
 			requisition.Accounts.Should().BeEmpty("accounts are not returned before user authorizes it");
-			requisition.Link.AbsoluteUri.Should().Contain("nordigen");
+			requisition.Link.AbsoluteUri.Should().StartWith("https://bankaccountdata.gocardless.com/psd2/start/");
 			requisition.AccountSelection.Should().BeFalse();
 			requisition.RedirectImmediate.Should().BeFalse();
 			requisition.Agreement.Should().BeNull();


### PR DESCRIPTION
According to Nordigen (now GoCardless) legacy URLs will stop working on 2024-02-20